### PR TITLE
Label image with game version + Shape fill option

### DIFF
--- a/Mappalachia/Class/Map.cs
+++ b/Mappalachia/Class/Map.cs
@@ -126,16 +126,24 @@ namespace Mappalachia
 			//Reset the current image to the background layer
 			finalImage = (Image)backgroundLayer.Clone();
 
+			Graphics imageGraphic = Graphics.FromImage(finalImage);
+			Font font = new Font(fontCollection.Families[0], fontSize);
+
+			//Draw the game version onto the map
+			string versionText = "Game version " + AssemblyInfo.gameVersion;
+			Brush brushWhite = new SolidBrush(Color.White);
+			SizeF versionBounds = new SizeF(mapDimension, mapDimension);
+			int versionTextHeight = (int)imageGraphic.MeasureString(versionText, font, versionBounds).Height;
+			RectangleF versionTextPosition = new RectangleF(0, mapDimension - versionTextHeight, versionBounds.Width, versionBounds.Height);
+			imageGraphic.DrawString(versionText, font, brushWhite, versionTextPosition);
+
 			if (FormMaster.legendItems.Count == 0)
 			{
 				mapFrame.Image = finalImage;
 				return;
 			}
 
-			Graphics imageGraphic = Graphics.FromImage(finalImage);
 			int totalLegendGroups = FormMaster.FindSumLegendGroups();
-
-			Font font = new Font(fontCollection.Families[0], fontSize);
 
 			if (SettingsPlot.mode == SettingsPlot.Mode.Icon)
 			{
@@ -343,15 +351,6 @@ namespace Mappalachia
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
 			}
-
-			//Draw the game version onto the map
-			string versionText = "Game version " + AssemblyInfo.gameVersion;
-			Brush brushWhite = new SolidBrush(Color.White);
-			SizeF versionBounds = new SizeF(mapDimension, mapDimension);
-			int versionTextHeight = (int)imageGraphic.MeasureString(versionText, font, versionBounds).Height;
-			RectangleF versionTextPosition = new RectangleF(0, mapDimension - versionTextHeight, versionBounds.Width, versionBounds.Height);
-
-			imageGraphic.DrawString(versionText, font, brushWhite, versionTextPosition);
 
 			mapFrame.Image = finalImage;
 		}

--- a/Mappalachia/Class/Map.cs
+++ b/Mappalachia/Class/Map.cs
@@ -344,6 +344,15 @@ namespace Mappalachia
 				GC.WaitForPendingFinalizers();
 			}
 
+			//Draw the game version onto the map
+			string versionText = "Game version " + AssemblyInfo.gameVersion;
+			Brush brushWhite = new SolidBrush(Color.White);
+			SizeF versionBounds = new SizeF(mapDimension, mapDimension);
+			int versionTextHeight = (int)imageGraphic.MeasureString(versionText, font, versionBounds).Height;
+			RectangleF versionTextPosition = new RectangleF(0, mapDimension - versionTextHeight, versionBounds.Width, versionBounds.Height);
+
+			imageGraphic.DrawString(versionText, font, brushWhite, versionTextPosition);
+
 			mapFrame.Image = finalImage;
 		}
 

--- a/Mappalachia/Class/PlotIcon.cs
+++ b/Mappalachia/Class/PlotIcon.cs
@@ -15,6 +15,7 @@ namespace Mappalachia.Class
 		readonly float quartSize;
 		readonly float threeQuartSize;
 		readonly Pen pen;
+		readonly Brush brush;
 		readonly Bitmap bitmap;
 		readonly Graphics icon;
 
@@ -33,6 +34,7 @@ namespace Mappalachia.Class
 			threeQuartSize = quartSize * 3;
 
 			pen = new Pen(Color.White, lineWidth);
+			brush = new SolidBrush(Color.White);
 			bitmap = new Bitmap(size, size);
 			icon = Graphics.FromImage(bitmap);
 			icon.SmoothingMode = SmoothingMode.AntiAlias;
@@ -64,7 +66,15 @@ namespace Mappalachia.Class
 					new PointF(halfSize, threeQuartSize), //Left
 					new PointF(threeQuartSize, halfSize), //Right
 				};
-				icon.DrawPolygon(pen, diamondCorners);
+
+				if (shape.fill)
+				{
+					icon.FillPolygon(brush, diamondCorners);
+				}
+				else
+				{
+					icon.DrawPolygon(pen, diamondCorners);
+				}
 			}
 
 			if (shape.square || shape.circle)
@@ -73,12 +83,26 @@ namespace Mappalachia.Class
 
 				if (shape.square)
 				{
-					icon.DrawRectangle(pen, halfRadiusRect);
+					if (shape.fill)
+					{
+						icon.FillRectangle(brush, halfRadiusRect);
+					}
+					else
+					{
+						icon.DrawRectangle(pen, halfRadiusRect);
+					}
 				}
 
 				if (shape.circle)
 				{
-					icon.DrawEllipse(pen, halfRadiusRect);
+					if (shape.fill)
+					{
+						icon.FillEllipse(brush, halfRadiusRect);
+					}
+					else
+					{
+						icon.DrawEllipse(pen, halfRadiusRect);
+					}
 				}
 			}
 

--- a/Mappalachia/Class/PlotIconShape.cs
+++ b/Mappalachia/Class/PlotIconShape.cs
@@ -10,16 +10,18 @@ namespace Mappalachia.Class
 		public readonly bool circle;
 		public readonly bool crosshairInner;
 		public readonly bool crosshairOuter;
+		public readonly bool fill;
 
 		static readonly Random rnd = new Random();
 
-		public PlotIconShape(bool diamond, bool square, bool circle, bool crosshairInner, bool crosshairOuter)
+		public PlotIconShape(bool diamond, bool square, bool circle, bool crosshairInner, bool crosshairOuter, bool fill)
 		{
 			this.diamond = diamond;
 			this.square = square;
 			this.circle = circle;
 			this.crosshairInner = crosshairInner;
 			this.crosshairOuter = crosshairOuter;
+			this.fill = fill;
 		}
 
 		//Instantiate with random shapes
@@ -30,6 +32,7 @@ namespace Mappalachia.Class
 			circle = rnd.Next(2) == 1;
 			crosshairInner = rnd.Next(2) == 1;
 			crosshairOuter = rnd.Next(2) == 1;
+			fill = false;
 
 			//Verify we have selected at least one option
 			if (!(diamond || square || circle || crosshairInner || crosshairOuter))

--- a/Mappalachia/Class/SettingsPlot.cs
+++ b/Mappalachia/Class/SettingsPlot.cs
@@ -35,11 +35,11 @@ namespace Mappalachia.Class
 
 		public static readonly List<PlotIconShape> paletteShapeDefault = new List<PlotIconShape>
 		{
-			//				Diamond square circle inner outer
-			new PlotIconShape(false, false, true, false, true),
-			new PlotIconShape(true, false, false, false, false),
-			new PlotIconShape(false, false, false, true, false),
-			new PlotIconShape(false, true, true, false, false),
+			//				Diamond square circle inner outer  fill
+			new PlotIconShape(false, false, true, false, true, false),
+			new PlotIconShape(true, false, false, false, false, false),
+			new PlotIconShape(false, false, false, true, false, false),
+			new PlotIconShape(false, true, true, false, false, false),
 		};
 
 		public static readonly List<Color> paletteColorDefault = new List<Color>

--- a/Mappalachia/Form/FormPlotIconSettings.Designer.cs
+++ b/Mappalachia/Form/FormPlotIconSettings.Designer.cs
@@ -59,6 +59,7 @@
 			this.colorDialogPalette = new System.Windows.Forms.ColorDialog();
 			this.groupBoxGeneral = new System.Windows.Forms.GroupBox();
 			this.groupBoxIconPalette = new System.Windows.Forms.GroupBox();
+			this.checkBoxFill = new System.Windows.Forms.CheckBox();
 			this.groupBoxColorPalette.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarIconWidth)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.trackBarIconSize)).BeginInit();
@@ -250,7 +251,7 @@
 			this.trackBarIconWidth.Name = "trackBarIconWidth";
 			this.trackBarIconWidth.Size = new System.Drawing.Size(104, 45);
 			this.trackBarIconWidth.TabIndex = 1;
-			this.toolTipControls.SetToolTip(this.trackBarIconWidth, "The width of the lines which form the plot icon.");
+			this.toolTipControls.SetToolTip(this.trackBarIconWidth, "The width of the lines (and shadows) which form the plot icon.");
 			this.trackBarIconWidth.Value = 1;
 			// 
 			// labelIconWidth
@@ -262,7 +263,7 @@
 			this.labelIconWidth.Size = new System.Drawing.Size(59, 13);
 			this.labelIconWidth.TabIndex = 10;
 			this.labelIconWidth.Text = "Icon Width";
-			this.toolTipControls.SetToolTip(this.labelIconWidth, "The width of the lines which form the plot icon.");
+			this.toolTipControls.SetToolTip(this.labelIconWidth, "The width of the lines (and shadows) which form the plot icon.");
 			// 
 			// trackBarIconSize
 			// 
@@ -371,6 +372,7 @@
 			// 
 			// groupBoxIconPalette
 			// 
+			this.groupBoxIconPalette.Controls.Add(this.checkBoxFill);
 			this.groupBoxIconPalette.Controls.Add(this.listViewShapePalette);
 			this.groupBoxIconPalette.Controls.Add(this.checkBoxCrosshairOuter);
 			this.groupBoxIconPalette.Controls.Add(this.buttonRemoveShape);
@@ -385,6 +387,17 @@
 			this.groupBoxIconPalette.TabIndex = 2;
 			this.groupBoxIconPalette.TabStop = false;
 			this.groupBoxIconPalette.Text = "Shape Palette";
+			// 
+			// checkBoxFill
+			// 
+			this.checkBoxFill.AutoSize = true;
+			this.checkBoxFill.Location = new System.Drawing.Point(80, 141);
+			this.checkBoxFill.Name = "checkBoxFill";
+			this.checkBoxFill.Size = new System.Drawing.Size(72, 17);
+			this.checkBoxFill.TabIndex = 8;
+			this.checkBoxFill.Text = "Fill Shape";
+			this.toolTipControls.SetToolTip(this.checkBoxFill, "Fill hollow shapes with solid color.");
+			this.checkBoxFill.UseVisualStyleBackColor = true;
 			// 
 			// FormPlotIconSettings
 			// 
@@ -450,5 +463,6 @@
 		private System.Windows.Forms.TrackBar trackBarIconOpacity;
 		private System.Windows.Forms.TrackBar trackBarShadowOpacity;
 		private System.Windows.Forms.Button buttonReset;
+		private System.Windows.Forms.CheckBox checkBoxFill;
 	}
 }

--- a/Mappalachia/Form/FormPlotIconSettings.cs
+++ b/Mappalachia/Form/FormPlotIconSettings.cs
@@ -55,7 +55,7 @@ namespace Mappalachia
 			foreach (ListViewItem shape in listViewShapePalette.Items)
 			{
 				shape.Selected = true;
-				tempShapePalette.Add(new PlotIconShape(checkBoxDiamond.Checked, checkBoxSquare.Checked, checkBoxCircle.Checked, checkBoxCrosshairInner.Checked, checkBoxCrosshairOuter.Checked));
+				tempShapePalette.Add(new PlotIconShape(checkBoxDiamond.Checked, checkBoxSquare.Checked, checkBoxCircle.Checked, checkBoxCrosshairInner.Checked, checkBoxCrosshairOuter.Checked, checkBoxFill.Checked));
 			}
 
 			SettingsPlotIcon.paletteShape = new List<PlotIconShape>(tempShapePalette);
@@ -198,6 +198,7 @@ namespace Mappalachia
 			checkBoxCircle.Enabled = isEnabled;
 			checkBoxCrosshairInner.Enabled = isEnabled;
 			checkBoxCrosshairOuter.Enabled = isEnabled;
+			checkBoxFill.Enabled = isEnabled;
 
 			if (!isEnabled)
 			{
@@ -206,6 +207,7 @@ namespace Mappalachia
 				checkBoxCircle.Checked = isEnabled;
 				checkBoxCrosshairInner.Checked = isEnabled;
 				checkBoxCrosshairOuter.Checked = isEnabled;
+				checkBoxFill.Checked = isEnabled;
 			}
 		}
 
@@ -272,7 +274,7 @@ namespace Mappalachia
 			if (listViewShapePalette.SelectedItems.Count == 0)
 			{
 				placeholderShapePalette[lastSelectedShapeIndex] =
-					new PlotIconShape(checkBoxDiamond.Checked, checkBoxSquare.Checked, checkBoxCircle.Checked, checkBoxCrosshairInner.Checked, checkBoxCrosshairOuter.Checked);
+					new PlotIconShape(checkBoxDiamond.Checked, checkBoxSquare.Checked, checkBoxCircle.Checked, checkBoxCrosshairInner.Checked, checkBoxCrosshairOuter.Checked, checkBoxFill.Checked);
 			}
 
 			//Re-selecting - load in the settings.
@@ -287,6 +289,7 @@ namespace Mappalachia
 				checkBoxCircle.Checked = selectedShape.circle;
 				checkBoxCrosshairInner.Checked = selectedShape.crosshairInner;
 				checkBoxCrosshairOuter.Checked = selectedShape.crosshairOuter;
+				checkBoxFill.Checked = selectedShape.fill;
 
 				lastSelectedShapeIndex = selectedShapeIndex;
 			}

--- a/Mappalachia/Mappalachia.csproj
+++ b/Mappalachia/Mappalachia.csproj
@@ -186,9 +186,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite">
       <Version>5.0.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Memory">
-      <Version>4.5.4</Version>
-    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>5.0.0</Version>
     </PackageReference>

--- a/Mappalachia/Properties/AssemblyInfo.cs
+++ b/Mappalachia/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Mappalachia")]
 [assembly: AssemblyDescription("The complete mapping tool for Fallout 76.\r\n" +
 	"Mappalachia is a Windows Forms GUI for generating and exporting complex maps of entities within the Fallout 76 world.\r\n" +
-	"For Fallout 76 version 1.5.1.3.")]
+	"For Fallout 76 version " + Mappalachia.AssemblyInfo.gameVersion + ".")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Mappalachia")]
@@ -37,3 +37,11 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.1.0")]
 [assembly: AssemblyFileVersion("1.0.1.0")]
 [assembly: NeutralResourcesLanguage("en-US")]
+
+namespace Mappalachia
+{
+	public static class AssemblyInfo
+	{
+		public const string gameVersion = "1.5.1.3";
+	}
+}

--- a/Mappalachia/Properties/AssemblyInfo.cs
+++ b/Mappalachia/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]
 [assembly: NeutralResourcesLanguage("en-US")]
 
 namespace Mappalachia


### PR DESCRIPTION
This PR adds two new features
- The game version is now printed in white at the bottom left of the map. This benefits us going forwards as maps exported to wikis etc are clearly labelled and indicate if they may be out of date
- In support of this feature, the game version is now isolated in a string under AssemblyInfo
- Shape palette shapes now have a 'Fill' option. This fills hollow shapes with solid color.
- Finally an unused System.Memory reference was removed. This must have slipped in during early dev