### PR TITLE
Add dev debug instructions without building db

### DIFF
--- a/FO76Edit/Edit Scripts/_m_lib.pas
+++ b/FO76Edit/Edit Scripts/_m_lib.pas
@@ -153,7 +153,7 @@ unit _m_lib;
 		//It would seem that Flora or Vein items *can* provide a representative name since they only give themselves or a nuked version...
 		//So - starting with the bottom item, work upwards until we find a name
 		if(DisplayName(item) = '') and ((pos('LPI_Flora', EditorID(item)) <> 0) or (pos('LPI_Vein', EditorID(item)) <> 0)) then begin
-			for i := ElementCount(leveledListEntries) downto 0 do begin
+			for i := ElementCount(leveledListEntries) - 1 downto 0 do begin
 				//Find the end of the leveled item list, directly under LVLO/Reference
 				result := nameFromRef(GetEditValue(ElementByName(ElementByName(ElementByIndex(leveledListEntries, i), 'LVLO - LVLO'), 'Reference')));
 

--- a/Guides_dev/EditScripts.md
+++ b/Guides_dev/EditScripts.md
@@ -4,13 +4,13 @@
 * A copy of Fallout76 installed on your machine
 
 ## Familiar with FO76Edit?
-If you know what you're doing with FO76Edit, you'll need to drop a FO76Edit installation onto the `\FO76Edit` folder and then run the `_m_RUNALL.pas` script. This will run all Mappalachia export scripts consecutively and should take around 14 minutes.<br/>
-Once complete the folder `\FO76Edit\Output` should be populated with 6 CSV files, and you can move on to the preprocessor.
+If you know what you're doing with FO76Edit, you'll need to drop a FO76Edit installation onto the `\FO76Edit\` folder and then run the `_m_RUNALL.pas` script. This will run all Mappalachia export scripts consecutively and should take around 14 minutes.<br/>
+Once complete the folder `\FO76Edit\Output\` should be populated with 6 CSV files, and you can move on to the preprocessor.
 <br/><br/>
 
 ## NOT Familiar with FO76Edit?
 
-The Pascal scripts found in `\FO76Edit\Edit Scripts` are built specifically to be used with the Fallout 76 Version of XEdit, also known as FO76Edit.<br/>
+The Pascal scripts found in `\FO76Edit\Edit Scripts\` are built specifically to be used with the Fallout 76 Version of XEdit, also known as FO76Edit.<br/>
 
 ### Installing FO76Edit
 FO76Edit is not distributed in this repository and you will need to grab it online.<br/>
@@ -18,7 +18,7 @@ There are a few versions of FO76Edit available. The 'official' version is [avail
 For a more up to date version, user Eckserah has spent significant time maintaining an up to date version mostly in line with Bethesda's patches. This version is [available via NukaCrypt](https://nukacrypt.com/ecksedit/latest).<br/>
 *Please note these are third party links. While I personally trust them, I can provide no guarantees.*<br/>
 <br/>
-Once you have downloaded FO76Edit, you should simply be able to dump the contents of the zip into the `\FO76Edit` folder. (You will note that the `\Edit Scripts` folder is already in place, populated with Mappalachia scripts).<br/>
+Once you have downloaded FO76Edit, you should simply be able to dump the contents of the zip into the `\FO76Edit\` folder. (You will note that the `Edit Scripts\` folder is already in place, populated with Mappalachia scripts).<br/>
 
 ### Launching FO76Edit
 If you only own Fallout76 through Steam, or installed Fallout76 in a non-default directory, you will need to launch FO76Edit with a launch parameter `-D:"<Path_to_FO76_Data_folder>"`.<br/>
@@ -29,7 +29,7 @@ Once in FO76Edit you will be prompted with which ESM to load. Select SeventySix.
 Expand SeventySix.esm in the tree on the left. Right click any element and select 'Apply Script'.<br/>
 Select `_m_RUNALL` as your script to run.<br/>
 This script runs all Mappalachia scripts consecutively and should take about 14 minutes to complete.<br/>
-Once completed you should see the folder `\FO76Edit\Output` has been populated with 6 CSV files.<br/>
+Once completed you should see the folder `\FO76Edit\Output\` has been populated with 6 CSV files.<br/>
 <br/>
 
 ### Next steps

--- a/Guides_dev/GUI.md
+++ b/Guides_dev/GUI.md
@@ -1,7 +1,7 @@
 # Mappalachia GUI
 
 ### Prerequisites and assumptions
-* You have already [built the database](Ingest.md)
+* You have already [built the database](Ingest.md) OR have a copy of `mappalachia.db` from a release
 * An installation of Visual Studio 2019
 * Experience using Mappalachia as an end user
 * Competency in C# .Net Framework and SQLite SQL
@@ -15,6 +15,14 @@ Mappalachia uses the .Net Framework V4.8, and also relies heavily on Microsoft.D
 As this point, you should simply be able to 'start debugging' in Visual Studio to get it to run.
 <br/>
 
+## Debugging without building the database
+Building the database is a multi-step process and you don't *need* to build it to debug the Mappalachia GUI, you just need a working copy of it.<br/>
+
+If you want to debug Mappalachia and skip out on the datamining steps, you need to grab a copy of the pre-assembled `mappalachia.db` from a release. This can be found in `\data\mappalachia.db`.<br/>
+To use this copy in your debugging, you should recreate the `\Mappalachia\data\` folder (alongside the `img\` and `font\` folders) and place `mappalachia.db` inside. Then rebuild the solution, and a post-build event will copy this to the relevant location(s) in `bin\`, therefore allowing you to debug.
+<br/>
+
+## Notes
 Failing full-scale code documentation, I will list the following key points to be aware of/understand;<br/>
 
 * There are three folders - Class, Form, and SQL.
@@ -26,12 +34,12 @@ Failing full-scale code documentation, I will list the following key points to b
 * The large majority of work done by the program is shared between `FormMaster` and `Map`. As you can imagine, `FormMaster` manages all the main UI controls, but it also holds the current search results and legends items. `Map` On the other hand does all the drawing of the map.
 * Almost all database queries ultimately come from `FormMaster`. These queries go to `Queries` which directly executes the SQL. Often `DataHelper` is used in-between to translate the data into something more user-friendly, or otherwise handle the query.
 * User-customisable settings and some defaults are stored in the three classes prefixed `Settings`. Other non-editable settings lie in their respective classes, such as at the top of `Map`.
-* There are post-build events configured to copy `\font`, `\data`, and `\img` to the build directory. If Mappalachia is complaining it can't find those files, you may just need to Rebuild.
+* There are post-build events configured to copy `font\`, `data\`, and `img\` to the build directory. If Mappalachia is complaining it can't find those files, you may just need to Rebuild.
 
 ## Packaging a release.
 In order to package a Mappalachia release there are a few steps.
 * Make sure the database has been newly compiled from the latest Fallout76 version.
 * Verify the database summary report has not indicated any issues.
 * Make sure to 'rebuild solution' to build the Mappalachia program in `Release` configuration.
-* Launch `Mappalachia\package_release.bat`. This batch script will essentially just check for a release build and then zip up the `bin\Release` folder and drop it in the `Mapplachia` folder besides the batch script.
+* Launch `Mappalachia\package_release.bat`. This batch script will essentially just check for a release build and then zip up the `bin\Release\` folder and drop it in the `\Mapplachia\` folder besides the batch script.
 * `Mappalachia.zip` is the file which should now be distributed to end users.

--- a/Guides_dev/Ingest.md
+++ b/Guides_dev/Ingest.md
@@ -13,11 +13,11 @@ Using SQLite, a single batch file creates the empty database structure, then ins
 
 ## Building the database
 Before we can build the database, we need a copy of the sqlite tools windows binary, called sqlite3.exe. This is distributed at the [SQLite downloads page](https://www.sqlite.org/download.html). Under 'Precompiled Binaries for Windows' find the sqlite-tools zip.<br/>
-Once you have placed that exe in the `\Database` folder, you can execute `build_database.bat` which should complete all the steps required to build the database.<br/>
-Once finished, the script will automatically move the db file to the data folder for the Mappalachia GUI at `\Mappalachia\data`.
+Once you have placed that exe in the `\Database\` folder, you can execute `build_database.bat` which should complete all the steps required to build the database.<br/>
+Once finished, the script will automatically move the db file to the data folder for the Mappalachia GUI at `\Mappalachia\data\`.
 
 ## Summary Report
-You will notice a txt file in `\Database` called `summary.txt`. This file is generated when the database is built and is intentionally source controlled.<br/>
+You will notice a txt file in `\Database\` called `summary.txt`. This file is generated when the database is built and is intentionally source controlled.<br/>
 Using git to visualise how the file changed, this report essentially acts as a canary for the reliability of data in the database, and allows us to quickly identify if anything has gone significantly wrong anywhere along the stage of exporting - as any wildly different values would indicate a problem.<br/>
 Checking this report should be a key step in updating the database for a new game version. While we would expect the values to change, any large changes, or empty fields should immediately signify an error.
 

--- a/Guides_dev/Preprocessor.md
+++ b/Guides_dev/Preprocessor.md
@@ -15,7 +15,7 @@ It carries out several key steps;
 
 ## How to use the Preprcoessor
 You simply need to build and run the preprocessor exe. There are no arguments or inputs required. The preprocessor assumes you have run the export scripts and have left the outputted CSVs where they were exported to.<br/>
-The preprocessing should take around 10 seconds to complete and (much like the export scripts) will also generate a new folder, `Preprocessor\Output` in which the 5 preprocessed CSVs will be placed.<br/>
+The preprocessing should take around 10 seconds to complete and (much like the export scripts) will also generate a new folder, `\Preprocessor\Output\` in which the 5 preprocessed CSVs will be placed.<br/>
 If any issues arise (most likely due to failing validation, after a new game update changes something), they will be reported to the console via a raised Exception.
 
 ### Next steps


### PR DESCRIPTION
Updates the GUI.md development doc to explain how to debug the GUI without all the datamining/db-building steps.

Also corrects the naming of folder paths in all dev guides, ensuring a preceding '\' means repo root, and ensures folder paths are also ended with '\' to clearly indicate they are not a file.

Finally corrects a minor inefficiency in an export script, where a loop was iterating pointlessly one-too-many times.