### PR TITLE
1.0.5.0 Support for non-standard DPI

### DIFF
--- a/Mappalachia/Class/Map.cs
+++ b/Mappalachia/Class/Map.cs
@@ -18,7 +18,7 @@ namespace Mappalachia
 		public static double yOffset = 5.2;
 
 		//Hidden settings
-		public static readonly int fontSize = 26;
+		public static readonly int fontSize = 36;
 		public static readonly int mapDimension = 4096; //All layer images should be this^2
 		public static readonly int maxZoom = (int)(mapDimension * 2.0);
 		public static readonly int minZoom = (int)(mapDimension * 0.05);
@@ -127,7 +127,7 @@ namespace Mappalachia
 			finalImage = (Image)backgroundLayer.Clone();
 
 			Graphics imageGraphic = Graphics.FromImage(finalImage);
-			Font font = new Font(fontCollection.Families[0], fontSize);
+			Font font = new Font(fontCollection.Families[0], fontSize, GraphicsUnit.Pixel);
 
 			//Draw the game version onto the map
 			string versionText = "Game version " + AssemblyInfo.gameVersion;
@@ -207,7 +207,7 @@ namespace Mappalachia
 					PlotIconShape shape = SettingsPlotIcon.paletteShape[shapeIndex];
 
 					//Draw the plot layer
-					imageGraphic.DrawImage(GenerateIconPlotLayer(mapItem, color, font, shape, legendCaretHeight, legendHeight, textOffset), 0, 0);
+					imageGraphic.DrawImage(GenerateIconPlotLayer(mapItem, color, font, shape, legendCaretHeight, legendHeight, textOffset), 0, 0, mapDimension, mapDimension);
 
 					legendCaretHeight += legendHeight; //Move the caret down for the next item, enough to fit the icon and the text
 

--- a/Mappalachia/Properties/AssemblyInfo.cs
+++ b/Mappalachia/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.1")]
-[assembly: AssemblyFileVersion("1.0.4.1")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: NeutralResourcesLanguage("en-US")]
 
 namespace Mappalachia


### PR DESCRIPTION
Ensures font and image drawing are independent of system DPI and prevents them being incorrectly scaled as this was resulting in incorrect map plots.