### PR TITLE
1.5.0.1 - bug fix patch

### DIFF
--- a/Mappalachia/Class/DataHelper.cs
+++ b/Mappalachia/Class/DataHelper.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Mappalachia
 {
-	// Interfaces with the database and provides helper methods, data translation and sorting
+	// Provides data helper methods, data translation and sorting
 	static class DataHelper
 	{
 		static readonly Dictionary<string, string> signatureDescription = new Dictionary<string, string>

--- a/Mappalachia/Class/IOManager.cs
+++ b/Mappalachia/Class/IOManager.cs
@@ -39,7 +39,6 @@ namespace Mappalachia
 
 		public static readonly string genericExceptionHelpText =
 			"To counter common errors, please check that:\n" +
-			"- Windows is up to date and you have the latest .Net Framework 4.8 installed.\n" +
 			"- Any security software has not accidentally removed or quarantined Mappalachia files, or is otherwise interfering.\n" +
 			"- The entire Mappalachia installation has been unzipped into one folder, with the same folder structure it came with.\n" +
 			"- None of the installation has been moved, renamed, or deleted.\n" +

--- a/Mappalachia/Class/Map.cs
+++ b/Mappalachia/Class/Map.cs
@@ -18,7 +18,7 @@ namespace Mappalachia
 		static double yOffset = 5.2;
 
 		// Hidden settings
-		public static readonly int mapDimension = 4096; // All layer images should be this^2
+		public static readonly int mapDimension = 4096; // All background images should be this^2
 		public static readonly int maxZoom = (int)(mapDimension * 2.0);
 		public static readonly int minZoom = (int)(mapDimension * 0.05);
 

--- a/Mappalachia/Form/FormMaster.Designer.cs
+++ b/Mappalachia/Form/FormMaster.Designer.cs
@@ -1288,7 +1288,8 @@ namespace Mappalachia
             // FormMaster
             // 
             this.AcceptButton = this.buttonSearch;
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.SystemColors.ControlDarkDark;
             this.ClientSize = new System.Drawing.Size(1674, 896);
             this.Controls.Add(this.progressBarMain);

--- a/Mappalachia/Form/FormMaster.Designer.cs
+++ b/Mappalachia/Form/FormMaster.Designer.cs
@@ -625,7 +625,7 @@ namespace Mappalachia
             this.columnSearchAmount.HeaderText = "Amount";
             this.columnSearchAmount.Name = "columnSearchAmount";
             this.columnSearchAmount.ReadOnly = true;
-            this.columnSearchAmount.ToolTipText = "The amount \"The amount of instances which can be found in the listed location.";
+            this.columnSearchAmount.ToolTipText = "The amount of instances which can be found in the listed location.";
             // 
             // columnSearchLocation
             // 

--- a/Mappalachia/Form/FormMaster.Designer.cs
+++ b/Mappalachia/Form/FormMaster.Designer.cs
@@ -554,7 +554,7 @@ namespace Mappalachia
             this.columnSearchIndex});
             this.gridViewSearchResults.Location = new System.Drawing.Point(6, 311);
             this.gridViewSearchResults.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.gridViewSearchResults.MinimumSize = new System.Drawing.Size(789, 180);
+            this.gridViewSearchResults.MinimumSize = new System.Drawing.Size(0, 180);
             this.gridViewSearchResults.Name = "gridViewSearchResults";
             this.gridViewSearchResults.ReadOnly = true;
             this.gridViewSearchResults.RowHeadersVisible = false;
@@ -780,7 +780,7 @@ namespace Mappalachia
             this.columnLegendDisplayName});
             this.gridViewLegend.Location = new System.Drawing.Point(6, 600);
             this.gridViewLegend.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.gridViewLegend.MinimumSize = new System.Drawing.Size(789, 180);
+            this.gridViewLegend.MinimumSize = new System.Drawing.Size(0, 180);
             this.gridViewLegend.Name = "gridViewLegend";
             this.gridViewLegend.RowHeadersVisible = false;
             this.gridViewLegend.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
@@ -1212,7 +1212,7 @@ namespace Mappalachia
             // splitContainerMain.Panel1
             // 
             this.splitContainerMain.Panel1.AutoScroll = true;
-            this.splitContainerMain.Panel1.AutoScrollMinSize = new System.Drawing.Size(820, 820);
+            this.splitContainerMain.Panel1.AutoScrollMinSize = new System.Drawing.Size(680, 820);
             this.splitContainerMain.Panel1.Controls.Add(this.checkBoxAddAsGroup);
             this.splitContainerMain.Panel1.Controls.Add(this.buttonRemoveFromLegend);
             this.splitContainerMain.Panel1.Controls.Add(this.buttonAddToLegend);

--- a/Mappalachia/Form/FormMaster.Designer.cs
+++ b/Mappalachia/Form/FormMaster.Designer.cs
@@ -818,7 +818,7 @@ namespace Mappalachia
             // 
             this.labelMinSpawnChance.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.labelMinSpawnChance.AutoSize = true;
-            this.labelMinSpawnChance.Location = new System.Drawing.Point(4, 200);
+            this.labelMinSpawnChance.Location = new System.Drawing.Point(4, 196);
             this.labelMinSpawnChance.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelMinSpawnChance.Name = "labelMinSpawnChance";
             this.labelMinSpawnChance.Size = new System.Drawing.Size(162, 15);
@@ -829,7 +829,7 @@ namespace Mappalachia
             // numericUpDownNPCSpawnThreshold
             // 
             this.numericUpDownNPCSpawnThreshold.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.numericUpDownNPCSpawnThreshold.Location = new System.Drawing.Point(7, 218);
+            this.numericUpDownNPCSpawnThreshold.Location = new System.Drawing.Point(7, 215);
             this.numericUpDownNPCSpawnThreshold.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.numericUpDownNPCSpawnThreshold.Name = "numericUpDownNPCSpawnThreshold";
             this.numericUpDownNPCSpawnThreshold.Size = new System.Drawing.Size(110, 23);
@@ -842,7 +842,7 @@ namespace Mappalachia
             // buttonSearchScrap
             // 
             this.buttonSearchScrap.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonSearchScrap.Location = new System.Drawing.Point(65, 215);
+            this.buttonSearchScrap.Location = new System.Drawing.Point(66, 213);
             this.buttonSearchScrap.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonSearchScrap.Name = "buttonSearchScrap";
             this.buttonSearchScrap.Size = new System.Drawing.Size(105, 27);
@@ -856,7 +856,7 @@ namespace Mappalachia
             // buttonSearchNPC
             // 
             this.buttonSearchNPC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonSearchNPC.Location = new System.Drawing.Point(124, 216);
+            this.buttonSearchNPC.Location = new System.Drawing.Point(124, 213);
             this.buttonSearchNPC.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonSearchNPC.Name = "buttonSearchNPC";
             this.buttonSearchNPC.Size = new System.Drawing.Size(105, 27);
@@ -1103,7 +1103,7 @@ namespace Mappalachia
             this.groupBoxFilterByLockLevel.Controls.Add(this.listViewFilterLockTypes);
             this.groupBoxFilterByLockLevel.Controls.Add(this.buttonDeselectAllLock);
             this.groupBoxFilterByLockLevel.Controls.Add(this.buttonSelectAllLock);
-            this.groupBoxFilterByLockLevel.Location = new System.Drawing.Point(398, 37);
+            this.groupBoxFilterByLockLevel.Location = new System.Drawing.Point(393, 37);
             this.groupBoxFilterByLockLevel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBoxFilterByLockLevel.Name = "groupBoxFilterByLockLevel";
             this.groupBoxFilterByLockLevel.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -1120,7 +1120,7 @@ namespace Mappalachia
             this.groupBoxFilterByCategory.Controls.Add(this.listViewFilterSignatures);
             this.groupBoxFilterByCategory.Controls.Add(this.buttonDeselectAllSignature);
             this.groupBoxFilterByCategory.Controls.Add(this.buttonSelectAllSignature);
-            this.groupBoxFilterByCategory.Location = new System.Drawing.Point(7, 37);
+            this.groupBoxFilterByCategory.Location = new System.Drawing.Point(6, 37);
             this.groupBoxFilterByCategory.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBoxFilterByCategory.Name = "groupBoxFilterByCategory";
             this.groupBoxFilterByCategory.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -1160,11 +1160,11 @@ namespace Mappalachia
             // 
             this.groupBoxScrapSearch.Controls.Add(this.listBoxScrap);
             this.groupBoxScrapSearch.Controls.Add(this.buttonSearchScrap);
-            this.groupBoxScrapSearch.Location = new System.Drawing.Point(306, 7);
+            this.groupBoxScrapSearch.Location = new System.Drawing.Point(306, 4);
             this.groupBoxScrapSearch.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBoxScrapSearch.Name = "groupBoxScrapSearch";
             this.groupBoxScrapSearch.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBoxScrapSearch.Size = new System.Drawing.Size(237, 249);
+            this.groupBoxScrapSearch.Size = new System.Drawing.Size(237, 246);
             this.groupBoxScrapSearch.TabIndex = 7;
             this.groupBoxScrapSearch.TabStop = false;
             this.groupBoxScrapSearch.Text = "Scrap Search";
@@ -1176,11 +1176,11 @@ namespace Mappalachia
             this.groupBoxNPCSearch.Controls.Add(this.labelMinSpawnChance);
             this.groupBoxNPCSearch.Controls.Add(this.numericUpDownNPCSpawnThreshold);
             this.groupBoxNPCSearch.Controls.Add(this.buttonSearchNPC);
-            this.groupBoxNPCSearch.Location = new System.Drawing.Point(62, 7);
+            this.groupBoxNPCSearch.Location = new System.Drawing.Point(61, 4);
             this.groupBoxNPCSearch.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBoxNPCSearch.Name = "groupBoxNPCSearch";
             this.groupBoxNPCSearch.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBoxNPCSearch.Size = new System.Drawing.Size(237, 249);
+            this.groupBoxNPCSearch.Size = new System.Drawing.Size(237, 246);
             this.groupBoxNPCSearch.TabIndex = 6;
             this.groupBoxNPCSearch.TabStop = false;
             this.groupBoxNPCSearch.Text = "NPC Search";
@@ -1189,7 +1189,7 @@ namespace Mappalachia
             // pictureBoxMapPreview
             // 
             this.pictureBoxMapPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)));
-            this.pictureBoxMapPreview.Location = new System.Drawing.Point(5, 0);
+            this.pictureBoxMapPreview.Location = new System.Drawing.Point(-11, 0);
             this.pictureBoxMapPreview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.pictureBoxMapPreview.Name = "pictureBoxMapPreview";
             this.pictureBoxMapPreview.Size = new System.Drawing.Size(820, 820);
@@ -1237,7 +1237,7 @@ namespace Mappalachia
             // 
             this.checkBoxAddAsGroup.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.checkBoxAddAsGroup.AutoSize = true;
-            this.checkBoxAddAsGroup.Location = new System.Drawing.Point(161, 575);
+            this.checkBoxAddAsGroup.Location = new System.Drawing.Point(160, 574);
             this.checkBoxAddAsGroup.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.checkBoxAddAsGroup.Name = "checkBoxAddAsGroup";
             this.checkBoxAddAsGroup.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
@@ -1288,8 +1288,7 @@ namespace Mappalachia
             // FormMaster
             // 
             this.AcceptButton = this.buttonSearch;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.BackColor = System.Drawing.SystemColors.ControlDarkDark;
             this.ClientSize = new System.Drawing.Size(1674, 896);
             this.Controls.Add(this.progressBarMain);

--- a/Mappalachia/Form/FormMaster.Designer.cs
+++ b/Mappalachia/Form/FormMaster.Designer.cs
@@ -1188,8 +1188,8 @@ namespace Mappalachia
             // 
             // pictureBoxMapPreview
             // 
-            this.pictureBoxMapPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)));
-            this.pictureBoxMapPreview.Location = new System.Drawing.Point(-11, 0);
+            this.pictureBoxMapPreview.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.pictureBoxMapPreview.Location = new System.Drawing.Point(9, 0);
             this.pictureBoxMapPreview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.pictureBoxMapPreview.Name = "pictureBoxMapPreview";
             this.pictureBoxMapPreview.Size = new System.Drawing.Size(820, 820);

--- a/Mappalachia/Form/FormMaster.cs
+++ b/Mappalachia/Form/FormMaster.cs
@@ -29,7 +29,10 @@ namespace Mappalachia
 		public FormMaster()
 		{
 			InitializeComponent();
-			Font = new Font(Font.Name, Font.Size * designDPI / CreateGraphics().DpiX, Font.Style, Font.Unit, Font.GdiCharSet, Font.GdiVerticalFont);
+			float dpiScaling = 1 / (designDPI / CreateGraphics().DpiX);
+			splitContainerMain.Panel1.AutoScrollMinSize = new Size(
+				(int)(splitContainerMain.Panel1.AutoScrollMinSize.Width * dpiScaling),
+				(int)(splitContainerMain.Panel1.AutoScrollMinSize.Height * dpiScaling));
 
 			Map.progressBarMain = progressBarMain;
 			progressBar = progressBarMain;

--- a/Mappalachia/Form/FormMaster.cs
+++ b/Mappalachia/Form/FormMaster.cs
@@ -19,14 +19,17 @@ namespace Mappalachia
 
 		public ProgressBar progressBar;
 
-		static bool warnedLVLINotUsed = false; // Flag for if we've displayed certain warnings, so as to only show once per run
+		static bool warnedLVLINotUsed = false; // Flag for if we've displayed this warning, so as to only show once per run
 		static bool forceDrawBaseLayer = false; // Force a base layer redraw at the next draw event
 		static Point lastMouseDownPos;
 		static readonly int searchResultsLargeAmount = 50; // Size of search results at which we need to disable the DataGridView before we populate it
 
+		static readonly float designDPI = 96; // The DPI which the form was designed for
+
 		public FormMaster()
 		{
 			InitializeComponent();
+			Font = new Font(Font.Name, Font.Size * designDPI / CreateGraphics().DpiX, Font.Style, Font.Unit, Font.GdiCharSet, Font.GdiVerticalFont);
 
 			Map.progressBarMain = progressBarMain;
 			progressBar = progressBarMain;
@@ -598,6 +601,8 @@ namespace Mappalachia
 			{
 				gridViewSearchResults.Enabled = true;
 			}
+
+			GC.Collect();
 		}
 
 		static void NotifyIfNoResults()

--- a/Mappalachia/Mappalachia.csproj
+++ b/Mappalachia/Mappalachia.csproj
@@ -41,7 +41,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Data.Sqlite">
-			<Version>6.0.3</Version>
+			<Version>6.0.4</Version>
 		</PackageReference>
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 		  <PrivateAssets>all</PrivateAssets>

--- a/Mappalachia/Properties/AssemblyInfo.cs
+++ b/Mappalachia/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.5.0.1")]
+[assembly: AssemblyFileVersion("1.5.0.1")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you fancy doing some data mining or development with Mappalachia then you may
 * Contributors to and developers of XEdit and FO76Edit, namely Eckserah.
 * Members of the FO76 Datamining Discord, for helping out with FO76Edit and Edit Scripts, and offering valuable knowledge and feedback based on their own experiences datamining and creating Fallout 76 maps.
 * Gilpo for providing great ideas and feedback for new Mappalachia features.
+* frame for reporting and helping to test DPI scaling issues.
 * Everyone who ever gave feedback to the original Mappalachia. Your feedback, comments, questions, and PMs were essential to defining and guiding the features I have been able to bring to life here.
 
 #### License

--- a/User_Guides/Customization.md
+++ b/User_Guides/Customization.md
@@ -1,7 +1,7 @@
 # Customization options
 
 ## Map Settings
-Under the 'Map' menu, there are several options which allow you to change the appearance of the overall map, in addition to some reset options;
+Under the 'Map' menu, there are several options which allow you to change the appearance of the overall map;
 
 ### Brightness
 This option brings up a dialog which allows you to tweak the percentage brightness of the underlying map image. Enter any value from 5% to 300%.


### PR DESCRIPTION
* Fixes the layout of the UI when a non-default DPI is used. The program will now scale properly
* Prevents spontaneous zooming behaviour which could occur when moving or zooming the map
* Allows the search results and legend views to shrink slightly horizontally before horizontal scroll bars kick in
* Removes an outdated reference to .net framework from an error message
* Corrects a typo in a tooltip
* Updates SQLite nuget package
* Minor user guide corrections

Resolves: https://github.com/AHeroicLlama/Mappalachia/issues/49