### PR TITLE
1.5.1.1 - rare parallel icon cache error bugfix

### DIFF
--- a/Mappalachia/Properties/AssemblyInfo.cs
+++ b/Mappalachia/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.1.1")]
+[assembly: AssemblyFileVersion("1.5.1.1")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Prevents a rare error that could popup when first drawing map marker icons. Uses more appropriate techniques for building a dictionary in parallel, and hides the error from the user until also attempting to draw marker icons in series first.