### PR TITLE
2.0.1.0 - Bug fixes

### DIFF
--- a/Docs/Developer/GUI.md
+++ b/Docs/Developer/GUI.md
@@ -22,3 +22,6 @@ Building the database and generating image assets is a multi-step process and yo
 If you want to debug Mappalachia and skip out on the datamining and asset generations steps, you need to grab a copy of the pre-assembled assets from a release.<br/>
 To use these in your debugging, copy the `img\` and `data\` folders from the root of a release, and place them in the `Assets\` folder at the root of the repository, then rebuild the project. A post-build event will copy them to the relevant location(s) in `bin\`, therefore allowing you to debug.
 <br/>
+
+### Next steps
+See [Deployment](Deployment.md) for the full process of packaging and deploying a release, including after a game update.

--- a/Library/CommonDatabase.cs
+++ b/Library/CommonDatabase.cs
@@ -19,10 +19,19 @@ namespace Library
 		}
 
 		// Shortcut to return a reader with the given query already executed
-		public static async Task<SqliteDataReader> GetReader(SqliteConnection connection, string queryText)
+		public static async Task<SqliteDataReader> GetReader(SqliteConnection connection, string queryText, Dictionary<string, object>? parameters = null)
 		{
 			SqliteCommand query = connection.CreateCommand();
 			query.CommandText = queryText;
+
+			if (parameters != null)
+			{
+				foreach (KeyValuePair<string, object> param in parameters)
+				{
+					query.Parameters.AddWithValue(param.Key, param.Value);
+				}
+			}
+
 			return await query.ExecuteReaderAsync().ConfigureAwait(false);
 		}
 

--- a/Mappalachia/Database.cs
+++ b/Mappalachia/Database.cs
@@ -470,9 +470,14 @@ namespace Mappalachia
 
 			string query = "SELECT x, y, z, instanceFormID FROM Position " +
 				"JOIN Container ON Container.containerFormID = Position.referenceFormID " +
-				$"WHERE contentFormID = {searchResult.Entity.FormID} AND quantity = {searchResult.SpawnWeight} AND lockLevel = '{searchResult.LockLevel.ToStringForQuery()}' AND spaceFormID = {space.FormID};";
+				$"WHERE contentFormID = {searchResult.Entity.FormID} AND quantity = $spawnWeight AND lockLevel = '{searchResult.LockLevel.ToStringForQuery()}' AND spaceFormID = {space.FormID};";
 
-			using SqliteDataReader reader = await GetReader(Connection, query);
+			Dictionary<string, object> parameters = new Dictionary<string, object>
+			{
+				{ "$spawnWeight", searchResult.SpawnWeight },
+			};
+
+			using SqliteDataReader reader = await GetReader(Connection, query, parameters);
 
 			while (reader.Read())
 			{
@@ -555,9 +560,14 @@ namespace Mappalachia
 
 			string query = "SELECT x, y, z, Position.instanceFormID FROM Position " +
 				"JOIN NPC ON npc.instanceFormID = Position.instanceFormID " +
-				$"WHERE npcName = '{searchResult.Entity.EditorID}' AND npc.spawnWeight = {searchResult.SpawnWeight} AND npc.spaceFormID = {space.FormID}";
+				$"WHERE npcName = '{searchResult.Entity.EditorID}' AND npc.spawnWeight = $spawnWeight AND npc.spaceFormID = {space.FormID}";
 
-			using SqliteDataReader reader = await GetReader(Connection, query);
+			Dictionary<string, object> parameters = new Dictionary<string, object>
+			{
+				{ "$spawnWeight", searchResult.SpawnWeight },
+			};
+
+			using SqliteDataReader reader = await GetReader(Connection, query, parameters);
 
 			while (reader.Read())
 			{
@@ -583,7 +593,12 @@ namespace Mappalachia
 
 			string query = "SELECT x, y, z, Position.instanceFormID FROM Position " +
 				"JOIN Scrap ON Scrap.junkFormID = Position.referenceFormID " +
-				$"WHERE component = '{searchResult.Entity.EditorID}' AND Scrap.componentQuantity = {searchResult.SpawnWeight} AND Position.spaceFormID = {space.FormID}";
+				$"WHERE component = '{searchResult.Entity.EditorID}' AND Scrap.componentQuantity = $spawnWeight AND Position.spaceFormID = {space.FormID}";
+
+			Dictionary<string, object> parameters = new Dictionary<string, object>
+			{
+				{ "$spawnWeight", searchResult.SpawnWeight },
+			};
 
 			using SqliteDataReader reader = await GetReader(Connection, query);
 

--- a/Mappalachia/Form/FormMain.Designer.cs
+++ b/Mappalachia/Form/FormMain.Designer.cs
@@ -562,7 +562,7 @@ namespace Mappalachia
 			drawInstanceFormIDToolStripMenuItem.Name = "drawInstanceFormIDToolStripMenuItem";
 			drawInstanceFormIDToolStripMenuItem.Size = new Size(240, 22);
 			drawInstanceFormIDToolStripMenuItem.Text = "Show Instance FormID";
-			drawInstanceFormIDToolStripMenuItem.ToolTipText = "(Advanced) Show the Form ID of the instance against its plot. Only applies to Standard or Topographic plot mode.";
+			drawInstanceFormIDToolStripMenuItem.ToolTipText = "(Advanced) Show the Form ID of the instance against its plot. Generally only applies to Standard or Topographic plot mode.";
 			drawInstanceFormIDToolStripMenuItem.Click += Plot_DrawInstanceFormIDs_Click;
 			// 
 			// helpToolStripMenuItem

--- a/Mappalachia/Map.cs
+++ b/Mappalachia/Map.cs
@@ -284,7 +284,7 @@ namespace Mappalachia
 				foreach (Instance instance in await Database.GetInstances(item, item.Space))
 				{
 					// Skip plots in cluster and heatmap mode since they're not plotted distinctly,
-					// unless they're shapes which are
+					// unless they're shapes.
 					if (instance.PrimitiveShape is null && (settings.PlotSettings.Mode == PlotMode.Cluster || settings.PlotSettings.Mode == PlotMode.Heatmap))
 					{
 						continue;

--- a/Mappalachia/Map.cs
+++ b/Mappalachia/Map.cs
@@ -538,19 +538,13 @@ namespace Mappalachia
 						continue;
 					}
 
-					// If the cluster is actually a polygon and not a line nor a point, draw the polygon, else, just use normal icons
-					if (cluster.Members.Count > 2)
+					// If the cluster is not just a single point, draw the polygon
+					if (cluster.Members.Count > 1)
 					{
 						graphics.DrawPolygon(pen, cluster.Members.Select(m => m.Coord.AsImagePoint(settings)).ToList().GetConvexHull());
-						graphics.DrawStringCentered(Math.Round(cluster.GetWeight(), 2).ToString(), font, brush, cluster.Members.GetCentroid().AsImagePoint(settings));
 					}
-					else
-					{
-						foreach (Instance instance in cluster.Members)
-						{
-							graphics.DrawImageCentered(leadItem.PlotIcon.GetImage(), instance.Coord.AsImagePoint(settings));
-						}
-					}
+
+					graphics.DrawStringCentered(Math.Round(cluster.GetWeight(), 2).ToString(), font, brush, cluster.Members.GetCentroid().AsImagePoint(settings));
 				}
 			}
 		}

--- a/Mappalachia/Map.cs
+++ b/Mappalachia/Map.cs
@@ -30,7 +30,7 @@ namespace Mappalachia
 
 	public static class Map
 	{
-		public static int BlastRadius { get; } = 20460; // 0x002D1160
+		public static int BlastRadius { get; } = 20460; // See GLOB 0x002D1160
 
 		public static int CompassSize { get; } = MapImageResolution / 8;
 
@@ -227,6 +227,14 @@ namespace Mappalachia
 
 				Image? image = tile.GetSpotlightTileImage();
 
+				SmoothingMode priorSmoothingMode = graphics.SmoothingMode;
+				PixelOffsetMode priorPixelOffsetMode = graphics.PixelOffsetMode;
+				InterpolationMode priorInterpolationMode = graphics.InterpolationMode;
+
+				graphics.SmoothingMode = SmoothingMode.None;
+				graphics.PixelOffsetMode = PixelOffsetMode.Half;
+				graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+
 				if (image is not null)
 				{
 					i++;
@@ -235,6 +243,10 @@ namespace Mappalachia
 
 					graphics.DrawImage(image, tile.GetRectangle().AsImageRectangle(settings));
 				}
+
+				graphics.SmoothingMode = priorSmoothingMode;
+				graphics.PixelOffsetMode = priorPixelOffsetMode;
+				graphics.InterpolationMode = priorInterpolationMode;
 
 #if DEBUG_SPOTLIGHT
 				graphics.DrawStringCentered(
@@ -633,11 +645,23 @@ namespace Mappalachia
 			float height = legendRect.Height;
 			float step = height / divisions;
 
+			SmoothingMode priorSmoothingMode = graphics.SmoothingMode;
+			PixelOffsetMode priorPixelOffsetMode = graphics.PixelOffsetMode;
+			InterpolationMode priorInterpolationMode = graphics.InterpolationMode;
+
+			graphics.SmoothingMode = SmoothingMode.None;
+			graphics.PixelOffsetMode = PixelOffsetMode.Half;
+			graphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+
 			for (float y = 0; y < height; y += step)
 			{
 				RectangleF sliceRect = new RectangleF(legendRect.X, legendRect.Y + y, legendRect.Width, step);
 				graphics.FillRectangle(new SolidBrush(LerpColors(settings.PlotSettings.PlotStyleSettings.SecondaryPalette.ToArray(), Math.Abs(y - height) / (double)height).WithAlpha(TopographLegendAlpha)), sliceRect);
 			}
+
+			graphics.SmoothingMode = priorSmoothingMode;
+			graphics.PixelOffsetMode = priorPixelOffsetMode;
+			graphics.InterpolationMode = priorInterpolationMode;
 		}
 
 		// Draws the region instance


### PR DESCRIPTION
Prevents visual seams between spotlight tiles (And the topographic key)
prevents a "form id" of 0000000 being shown for regions
Amends cluster behaviour so that clusters with 1 or 2 plots are still drawn, with their weight
Fixes a bug where locale settings with a comma decimal separator would cause errors when plotting NPCs
When enabled and relevant, instance FormID for volumes is shown regardless of plot mode
